### PR TITLE
singleStudentDataObj

### DIFF
--- a/gravityforms-external-data-fields/gravityforms-external-data-fields.php
+++ b/gravityforms-external-data-fields/gravityforms-external-data-fields.php
@@ -43,10 +43,16 @@ add_action( 'wp_enqueue_scripts', 'gfedf_disable_input_fields' );
 $gfedf_studentdata = new studentData();
 function gfedf_get_student_data()
 {
+  debug_log("(wp) Getting student data...");
+
   global $gfedf_studentdata;
-  $gfedf_studentdata = new studentData(requireAuthentication::getCurrentUser());
+  $username = requireAuthentication::getCurrentUser();
+  debug_log("Current user is '$username'");
+  $gfedf_studentdata = new studentData($username);
+  debug_log("StudentData:\n".print_r($gfedf_studentdata, true));
 }
-add_action("init", "gfedf_get_student_data");
+// This action needs to run AFTER the user has been identified by the requireAuthentication class
+add_action("wp", "gfedf_get_student_data", 20);
 
 #########################
 // Pre-populate Fields
@@ -58,48 +64,66 @@ add_action("init", "gfedf_get_student_data");
 	// SID
 	add_filter('gform_field_value_bc_sid', 'populate_bc_sid');
 	function populate_bc_sid($value){
+    debug_log("(= gform_field_value_bc_sid =) Setting SID...");
+
     global $gfedf_studentdata;
     $bc_sid = $gfedf_studentdata->getStudentID();
+    debug_log("...'$bc_sid'");
 		return $bc_sid;
 	}
 
 	// First Name
 	add_filter('gform_field_value_bc_first_name', 'populate_bc_first_name');
 	function populate_bc_first_name($value){
+    debug_log("(= gform_field_value_bc_first_name =) Setting first name...");
+
     global $gfedf_studentdata;
 		$bc_first_name = $gfedf_studentdata->getFirstName();
+    debug_log("...'$bc_first_name'");
 		return $bc_first_name;
 	}
 
 	// First Name
 	add_filter('gform_field_value_bc_last_name', 'populate_bc_last_name');
 	function populate_bc_last_name($value){
+    debug_log("(= gform_field_value_bc_last_name =) Setting last name...");
+
     global $gfedf_studentdata;
 		$bc_last_name = $gfedf_studentdata->getLastName();
+    debug_log("...'$bc_last_name'");
 		return $bc_last_name;
 	}
 
 	// BC Email
 	add_filter('gform_field_value_bc_email', 'populate_bc_email');
 	function populate_bc_email($value){
+    debug_log("(= gform_field_value_bc_email =) Setting e-mail...");
+
     global $gfedf_studentdata;
 		$bc_email = $gfedf_studentdata->getEmailAddress();
+    debug_log("...'$bc_email'");
 		return $bc_email;
 	}
 
 	// Day Phone
 	add_filter('gform_field_value_bc_dayphone', 'populate_bc_dayphone');
 	function populate_bc_dayphone($value){
+    debug_log("(= gform_field_value_bc_dayphone =) Setting daytime phone...");
+
     global $gfedf_studentdata;
 		$bc_dayphone = $gfedf_studentdata->getDaytimePhone();
+    debug_log("...'$bc_dayphone'");
 		return $bc_dayphone;
 	}
 
 	// Evening Phone
 	add_filter('gform_field_value_bc_evephone', 'populate_bc_evephone');
 	function populate_bc_evephone($value){
+    debug_log("(= gform_field_value_bc_evephone =) Setting evening phone...");
+
     global $gfedf_studentdata;
 		$bc_evephone = $gfedf_studentdata->getEveningPhone();
+    debug_log("...'$bc_evephone'");
 		return $bc_evephone;
 	}
 

--- a/gravityforms-external-data-fields/requireAuthentication.php
+++ b/gravityforms-external-data-fields/requireAuthentication.php
@@ -47,15 +47,15 @@ class requireAuthentication
 
     // This check needs to run early enough in the WordPress page flow that a redirect (to the login page)
     // can occur before any content is written to the HTTP Response.
-    add_action( 'wp', array($this, "forceAuthentication") );
+    add_action( 'wp', array($this, "forceAuthentication"), 1 );
 
     $this->ssoInitialize();
   }
 
   /**
-   * @param $wp
+   *
    */
-  function forceAuthentication($wp)
+  function forceAuthentication()
   {
     // reset flag
     $this->authenticationForced = false;
@@ -199,22 +199,22 @@ class requireAuthentication
       }
       else
       {
+        debug_log("... failed...");
         if (!($this->authenticationForced))
         {
-          debug_log("Not already authenticated. Forcing login...");
+          debug_log("Redirecting to login server...");
           // redirect user to login page
           phpCAS::forceAuthentication();
           // set flag so we don't get caught in an endless loop
           $this->authenticationForced = true;
           // ...and check again.
+          debug_log("Recursively calling to verify user has authenticated...");
           return $this->ssoAuthenticated();
         }
         else
         {
           debug_log("Second attempt at authentication failed. See error log.");
           error_log("Forcing authentication failed. Unable to log user in.");
-
-          // TODO: what is the user experience if they can't/don't log in?
         }
       }
     }

--- a/gravityforms-external-data-fields/studentData.php
+++ b/gravityforms-external-data-fields/studentData.php
@@ -22,9 +22,9 @@ class studentData
   private $username = "";
   private $domain = studentData::UNSPECIFIED_DOMAIN;
 
-  function __construct($login = "")
+  function __construct($login = null)
   {
-    if((!isset($login)) || is_null($login) || empty($login))
+    if(is_null($login))
     {
       // parameterless constructor exists to be able to declare a global variable of $self that can be referenced later
       return null;


### PR DESCRIPTION
This pull request includes a potential fix for querying the database repeatedly each time
we need a value to pre-fill the form. I also fixed a "doing it wrong" error WordPress reported
with a call to wp_enqueue_script().

The solution turned out to not be quite as straight-forward as I'd hoped, but I learned even
more about how WordPress works - so that's good. I needed to tweak which action hooks are used
for the **studentData** and **requireAuthentication** objects as well as the priorities of those
actions.
